### PR TITLE
feat: execution for fragment arguments syntax

### DIFF
--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -59,6 +59,13 @@ const TestComplexScalar = new GraphQLScalarType({
   },
 });
 
+const NestedType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'NestedType',
+  fields: {
+    echo: fieldWithInputArg({ type: GraphQLString }),
+  },
+});
+
 const TestInputObject = new GraphQLInputObjectType({
   name: 'TestInputObject',
   fields: {
@@ -129,6 +136,10 @@ const TestType = new GraphQLObjectType({
       defaultValue: 'Hello World',
     }),
     list: fieldWithInputArg({ type: new GraphQLList(GraphQLString) }),
+    nested: {
+      type: NestedType,
+      resolve: () => ({}),
+    },
     nnList: fieldWithInputArg({
       type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
     }),
@@ -150,6 +161,14 @@ function executeQuery(
   variableValues?: { [variable: string]: unknown },
 ) {
   const document = parse(query);
+  return executeSync({ schema, document, variableValues });
+}
+
+function executeQueryWithFragmentArguments(
+  query: string,
+  variableValues?: { [variable: string]: unknown },
+) {
+  const document = parse(query, { experimentalFragmentArguments: true });
   return executeSync({ schema, document, variableValues });
 }
 
@@ -1133,6 +1152,286 @@ describe('Execute: Handles inputs', () => {
               'Too many errors processing variables, error limit reached. Execution aborted.',
           },
         ],
+      });
+    });
+  });
+
+  describe('using fragment arguments', () => {
+    it('when there are no fragment arguments', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a
+        }
+        fragment a on TestType {
+          fieldWithNonNullableStringInput(input: "A")
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInput: '"A"',
+        },
+      });
+    });
+
+    it('when a value is required and provided', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a(value: "A")
+        }
+        fragment a($value: String!) on TestType {
+          fieldWithNonNullableStringInput(input: $value)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInput: '"A"',
+        },
+      });
+    });
+
+    it('when a value is required and not provided', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a
+        }
+        fragment a($value: String!) on TestType {
+          fieldWithNullableStringInput(input: $value)
+        }
+      `);
+
+      expect(result).to.have.property('errors');
+      expect(result.errors).to.have.length(1);
+      expect(result.errors?.at(0)?.message).to.match(
+        /Argument "value" of required type "String!"/,
+      );
+    });
+
+    it('when the definition has a default and is provided', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a(value: "A")
+        }
+        fragment a($value: String! = "B") on TestType {
+          fieldWithNonNullableStringInput(input: $value)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInput: '"A"',
+        },
+      });
+    });
+
+    it('when the definition has a default and is not provided', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a
+        }
+        fragment a($value: String! = "B") on TestType {
+          fieldWithNonNullableStringInput(input: $value)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInput: '"B"',
+        },
+      });
+    });
+
+    it('when a definition has a default, is not provided, and spreads another fragment', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a
+        }
+        fragment a($a: String! = "B") on TestType {
+          ...b(b: $a)
+        }
+        fragment b($b: String!) on TestType {
+          fieldWithNonNullableStringInput(input: $b)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInput: '"B"',
+        },
+      });
+    });
+
+    it('when the definition has a non-nullable default and is provided null', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a(value: null)
+        }
+        fragment a($value: String! = "B") on TestType {
+          fieldWithNullableStringInput(input: $value)
+        }
+      `);
+
+      expect(result).to.have.property('errors');
+      expect(result.errors).to.have.length(1);
+      expect(result.errors?.at(0)?.message).to.match(
+        /Argument "value" of non-null type "String!"/,
+      );
+    });
+
+    it('when the definition has no default and is not provided', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a
+        }
+        fragment a($value: String) on TestType {
+          fieldWithNonNullableStringInputAndDefaultArgumentValue(input: $value)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInputAndDefaultArgumentValue:
+            '"Hello World"',
+        },
+      });
+    });
+
+    it('when an argument is shadowed by an operation variable', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query($x: String! = "A") {
+          ...a(x: "B")
+        }
+        fragment a($x: String) on TestType {
+          fieldWithNullableStringInput(input: $x)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNullableStringInput: '"B"',
+        },
+      });
+    });
+
+    it('when a nullable argument with a field default is not provided and shadowed by an operation variable', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query($x: String = "A") {
+          ...a
+        }
+        fragment a($x: String) on TestType {
+          fieldWithNonNullableStringInputAndDefaultArgumentValue(input: $x)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNonNullableStringInputAndDefaultArgumentValue:
+            '"Hello World"',
+        },
+      });
+    });
+
+    it('when a fragment-variable is shadowed by an intermediate fragment-spread but defined in the operation-variables', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query($x: String = "A") {
+          ...a
+        }
+        fragment a($x: String) on TestType {
+          ...b
+        }
+
+        fragment b on TestType {
+          fieldWithNullableStringInput(input: $x)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNullableStringInput: '"A"',
+        },
+      });
+    });
+
+    it('when a fragment is used with different args', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query($x: String = "Hello") {
+          a: nested {
+            ...a(x: "a")
+          }
+          b: nested {
+            ...a(x: "b", b: true)
+          }
+          hello: nested {
+            ...a(x: $x)
+          }
+        }
+        fragment a($x: String, $b: Boolean = false) on NestedType {
+          a: echo(input: $x) @skip(if: $b)
+          b: echo(input: $x) @include(if: $b)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          a: {
+            a: '"a"',
+          },
+          b: {
+            b: '"b"',
+          },
+          hello: {
+            a: '"Hello"',
+          },
+        },
+      });
+    });
+
+    it('when the argument variable is nested in a complex type', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a(value: "C")
+        }
+        fragment a($value: String) on TestType {
+          list(input: ["A", "B", $value, "D"])
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          list: '["A", "B", "C", "D"]',
+        },
+      });
+    });
+
+    it('when argument variables are used recursively', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query {
+          ...a(aValue: "C")
+        }
+        fragment a($aValue: String) on TestType {
+          ...b(bValue: $aValue)
+        }
+        fragment b($bValue: String) on TestType {
+          list(input: ["A", "B", $bValue, "D"])
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          list: '["A", "B", "C", "D"]',
+        },
+      });
+    });
+
+    it('when argument passed in as list', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query Q($opValue: String = "op") {
+          ...a(aValue: "A")
+        }
+        fragment a($aValue: String, $bValue: String) on TestType {
+          ...b(aValue: [$aValue, "B"], bValue: [$bValue, $opValue])
+        }
+        fragment b($aValue: [String], $bValue: [String], $cValue: String) on TestType {
+          aList: list(input: $aValue)
+          bList: list(input: $bValue)
+          cList: list(input: [$cValue])
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          aList: '["A", "B"]',
+          bList: '[null, "op"]',
+          cList: '[null]',
+        },
       });
     });
   });

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -22,33 +22,44 @@ import {
 } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
+import type { GraphQLVariableSignature } from '../utilities/getVariableSignature.js';
 import { typeFromAST } from '../utilities/typeFromAST.js';
 
-import { getArgumentValuesFromSpread, getDirectiveValues } from './values.js';
+import { experimentalGetArgumentValues, getDirectiveValues } from './values.js';
 
 export interface DeferUsage {
   label: string | undefined;
   parentDeferUsage: DeferUsage | undefined;
 }
 
+export interface FragmentVariables {
+  signatures: ObjMap<GraphQLVariableSignature>;
+  values: ObjMap<unknown>;
+}
+
 export interface FieldDetails {
   node: FieldNode;
-  deferUsage: DeferUsage | undefined;
-  fragmentVariableValues?: ObjMap<unknown> | undefined;
+  deferUsage?: DeferUsage | undefined;
+  fragmentVariables?: FragmentVariables | undefined;
 }
 
 export type FieldGroup = ReadonlyArray<FieldDetails>;
 
 export type GroupedFieldSet = ReadonlyMap<string, FieldGroup>;
 
+export interface FragmentDetails {
+  definition: FragmentDefinitionNode;
+  variableSignatures?: ObjMap<GraphQLVariableSignature> | undefined;
+}
+
 interface CollectFieldsContext {
   schema: GraphQLSchema;
-  fragments: ObjMap<FragmentDefinitionNode>;
+  fragments: ObjMap<FragmentDetails>;
+  variableValues: { [variable: string]: unknown };
+  fragmentVariableValues?: FragmentVariables;
   operation: OperationDefinitionNode;
   runtimeType: GraphQLObjectType;
   visitedFragmentNames: Set<string>;
-  localVariableValues: { [variable: string]: unknown } | undefined;
-  variableValues: { [variable: string]: unknown };
 }
 
 /**
@@ -62,7 +73,7 @@ interface CollectFieldsContext {
  */
 export function collectFields(
   schema: GraphQLSchema,
-  fragments: ObjMap<FragmentDefinitionNode>,
+  fragments: ObjMap<FragmentDetails>,
   variableValues: { [variable: string]: unknown },
   runtimeType: GraphQLObjectType,
   operation: OperationDefinitionNode,
@@ -75,10 +86,9 @@ export function collectFields(
   const context: CollectFieldsContext = {
     schema,
     fragments,
-    runtimeType,
     variableValues,
+    runtimeType,
     operation,
-    localVariableValues: undefined,
     visitedFragmentNames: new Set(),
   };
 
@@ -104,7 +114,7 @@ export function collectFields(
 // eslint-disable-next-line max-params
 export function collectSubfields(
   schema: GraphQLSchema,
-  fragments: ObjMap<FragmentDefinitionNode>,
+  fragments: ObjMap<FragmentDetails>,
   variableValues: { [variable: string]: unknown },
   operation: OperationDefinitionNode,
   returnType: GraphQLObjectType,
@@ -116,9 +126,8 @@ export function collectSubfields(
   const context: CollectFieldsContext = {
     schema,
     fragments,
-    runtimeType: returnType,
-    localVariableValues: undefined,
     variableValues,
+    runtimeType: returnType,
     operation,
     visitedFragmentNames: new Set(),
   };
@@ -144,19 +153,20 @@ export function collectSubfields(
   };
 }
 
+// eslint-disable-next-line max-params
 function collectFieldsImpl(
   context: CollectFieldsContext,
   selectionSet: SelectionSetNode,
   groupedFieldSet: AccumulatorMap<string, FieldDetails>,
   newDeferUsages: Array<DeferUsage>,
   deferUsage?: DeferUsage,
+  fragmentVariables?: FragmentVariables,
 ): void {
   const {
     schema,
     fragments,
-    runtimeType,
     variableValues,
-    localVariableValues,
+    runtimeType,
     operation,
     visitedFragmentNames,
   } = context;
@@ -164,20 +174,19 @@ function collectFieldsImpl(
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {
       case Kind.FIELD: {
-        const vars = localVariableValues ?? variableValues;
-        if (!shouldIncludeNode(vars, selection)) {
+        if (!shouldIncludeNode(selection, variableValues, fragmentVariables)) {
           continue;
         }
         groupedFieldSet.add(getFieldEntryKey(selection), {
           node: selection,
           deferUsage,
-          fragmentVariableValues: localVariableValues ?? undefined,
+          fragmentVariables,
         });
         break;
       }
       case Kind.INLINE_FRAGMENT: {
         if (
-          !shouldIncludeNode(variableValues, selection) ||
+          !shouldIncludeNode(selection, variableValues, fragmentVariables) ||
           !doesFragmentConditionMatch(schema, selection, runtimeType)
         ) {
           continue;
@@ -186,6 +195,7 @@ function collectFieldsImpl(
         const newDeferUsage = getDeferUsage(
           operation,
           variableValues,
+          fragmentVariables,
           selection,
           deferUsage,
         );
@@ -197,6 +207,7 @@ function collectFieldsImpl(
             groupedFieldSet,
             newDeferUsages,
             deferUsage,
+            fragmentVariables,
           );
         } else {
           newDeferUsages.push(newDeferUsage);
@@ -206,73 +217,72 @@ function collectFieldsImpl(
             groupedFieldSet,
             newDeferUsages,
             newDeferUsage,
+            fragmentVariables,
           );
         }
 
         break;
       }
       case Kind.FRAGMENT_SPREAD: {
-        const fragmentName = selection.name.value;
+        const fragName = selection.name.value;
 
         const newDeferUsage = getDeferUsage(
           operation,
           variableValues,
+          fragmentVariables,
           selection,
           deferUsage,
         );
 
         if (
           !newDeferUsage &&
-          (visitedFragmentNames.has(fragmentName) ||
-            !shouldIncludeNode(variableValues, selection))
+          (visitedFragmentNames.has(fragName) ||
+            !shouldIncludeNode(selection, variableValues, fragmentVariables))
         ) {
           continue;
         }
 
-        const fragment = fragments[fragmentName];
+        const fragment = fragments[fragName];
         if (
           fragment == null ||
-          !doesFragmentConditionMatch(schema, fragment, runtimeType)
+          !doesFragmentConditionMatch(schema, fragment.definition, runtimeType)
         ) {
           continue;
         }
 
-        // We need to introduce a concept of shadowing:
-        //
-        // - when a fragment defines a variable that is in the parent scope but not given
-        //   in the fragment-spread we need to look at this variable as undefined and check
-        //   whether the definition has a defaultValue, if not remove it from the variableValues.
-        // - when a fragment does not define a variable we need to copy it over from the parent
-        //   scope as that variable can still get used in spreads later on in the selectionSet.
-        // - when a value is passed in through the fragment-spread we need to copy over the key-value
-        //   into our variable-values.
-        context.localVariableValues = fragment.variableDefinitions
-          ? getArgumentValuesFromSpread(
+        const fragmentVariableSignatures = fragment.variableSignatures;
+        let newFragmentVariables: FragmentVariables | undefined;
+        if (fragmentVariableSignatures) {
+          newFragmentVariables = {
+            signatures: fragmentVariableSignatures,
+            values: experimentalGetArgumentValues(
               selection,
-              schema,
-              fragment.variableDefinitions,
+              Object.values(fragmentVariableSignatures),
               variableValues,
-              context.localVariableValues,
-            )
-          : undefined;
+              fragmentVariables,
+            ),
+          };
+        }
 
         if (!newDeferUsage) {
-          visitedFragmentNames.add(fragmentName);
+          visitedFragmentNames.add(fragName);
           collectFieldsImpl(
             context,
-            fragment.selectionSet,
+            fragment.definition.selectionSet,
             groupedFieldSet,
             newDeferUsages,
             deferUsage,
+            newFragmentVariables,
           );
         } else {
           newDeferUsages.push(newDeferUsage);
           collectFieldsImpl(
             context,
-            fragment.selectionSet,
+            fragment.definition.selectionSet,
             groupedFieldSet,
             newDeferUsages,
             newDeferUsage,
+            newFragmentVariables,
           );
         }
         break;
@@ -289,10 +299,16 @@ function collectFieldsImpl(
 function getDeferUsage(
   operation: OperationDefinitionNode,
   variableValues: { [variable: string]: unknown },
+  fragmentVariables: FragmentVariables | undefined,
   node: FragmentSpreadNode | InlineFragmentNode,
   parentDeferUsage: DeferUsage | undefined,
 ): DeferUsage | undefined {
-  const defer = getDirectiveValues(GraphQLDeferDirective, node, variableValues);
+  const defer = getDirectiveValues(
+    GraphQLDeferDirective,
+    node,
+    variableValues,
+    fragmentVariables,
+  );
 
   if (!defer) {
     return;
@@ -318,10 +334,16 @@ function getDeferUsage(
  * directives, where `@skip` has higher precedence than `@include`.
  */
 function shouldIncludeNode(
-  variableValues: { [variable: string]: unknown },
   node: FragmentSpreadNode | FieldNode | InlineFragmentNode,
+  variableValues: { [variable: string]: unknown },
+  fragmentVariables: FragmentVariables | undefined,
 ): boolean {
-  const skip = getDirectiveValues(GraphQLSkipDirective, node, variableValues);
+  const skip = getDirectiveValues(
+    GraphQLSkipDirective,
+    node,
+    variableValues,
+    fragmentVariables,
+  );
   if (skip?.if === true) {
     return false;
   }
@@ -330,6 +352,7 @@ function shouldIncludeNode(
     GraphQLIncludeDirective,
     node,
     variableValues,
+    fragmentVariables,
   );
   if (include?.if === false) {
     return false;

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -24,7 +24,7 @@ import type { GraphQLSchema } from '../type/schema.js';
 
 import { typeFromAST } from '../utilities/typeFromAST.js';
 
-import { getDirectiveValues } from './values.js';
+import { getArgumentValuesFromSpread, getDirectiveValues } from './values.js';
 
 export interface DeferUsage {
   label: string | undefined;
@@ -34,6 +34,7 @@ export interface DeferUsage {
 export interface FieldDetails {
   node: FieldNode;
   deferUsage: DeferUsage | undefined;
+  fragmentVariableValues?: ObjMap<unknown> | undefined;
 }
 
 export type FieldGroup = ReadonlyArray<FieldDetails>;
@@ -43,10 +44,11 @@ export type GroupedFieldSet = ReadonlyMap<string, FieldGroup>;
 interface CollectFieldsContext {
   schema: GraphQLSchema;
   fragments: ObjMap<FragmentDefinitionNode>;
-  variableValues: { [variable: string]: unknown };
   operation: OperationDefinitionNode;
   runtimeType: GraphQLObjectType;
   visitedFragmentNames: Set<string>;
+  localVariableValues: { [variable: string]: unknown } | undefined;
+  variableValues: { [variable: string]: unknown };
 }
 
 /**
@@ -73,9 +75,10 @@ export function collectFields(
   const context: CollectFieldsContext = {
     schema,
     fragments,
-    variableValues,
     runtimeType,
+    variableValues,
     operation,
+    localVariableValues: undefined,
     visitedFragmentNames: new Set(),
   };
 
@@ -113,8 +116,9 @@ export function collectSubfields(
   const context: CollectFieldsContext = {
     schema,
     fragments,
-    variableValues,
     runtimeType: returnType,
+    localVariableValues: undefined,
+    variableValues,
     operation,
     visitedFragmentNames: new Set(),
   };
@@ -150,8 +154,9 @@ function collectFieldsImpl(
   const {
     schema,
     fragments,
-    variableValues,
     runtimeType,
+    variableValues,
+    localVariableValues,
     operation,
     visitedFragmentNames,
   } = context;
@@ -159,12 +164,14 @@ function collectFieldsImpl(
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {
       case Kind.FIELD: {
-        if (!shouldIncludeNode(variableValues, selection)) {
+        const vars = localVariableValues ?? variableValues;
+        if (!shouldIncludeNode(vars, selection)) {
           continue;
         }
         groupedFieldSet.add(getFieldEntryKey(selection), {
           node: selection,
           deferUsage,
+          fragmentVariableValues: localVariableValues ?? undefined,
         });
         break;
       }
@@ -205,7 +212,7 @@ function collectFieldsImpl(
         break;
       }
       case Kind.FRAGMENT_SPREAD: {
-        const fragName = selection.name.value;
+        const fragmentName = selection.name.value;
 
         const newDeferUsage = getDeferUsage(
           operation,
@@ -216,21 +223,41 @@ function collectFieldsImpl(
 
         if (
           !newDeferUsage &&
-          (visitedFragmentNames.has(fragName) ||
+          (visitedFragmentNames.has(fragmentName) ||
             !shouldIncludeNode(variableValues, selection))
         ) {
           continue;
         }
 
-        const fragment = fragments[fragName];
+        const fragment = fragments[fragmentName];
         if (
           fragment == null ||
           !doesFragmentConditionMatch(schema, fragment, runtimeType)
         ) {
           continue;
         }
+
+        // We need to introduce a concept of shadowing:
+        //
+        // - when a fragment defines a variable that is in the parent scope but not given
+        //   in the fragment-spread we need to look at this variable as undefined and check
+        //   whether the definition has a defaultValue, if not remove it from the variableValues.
+        // - when a fragment does not define a variable we need to copy it over from the parent
+        //   scope as that variable can still get used in spreads later on in the selectionSet.
+        // - when a value is passed in through the fragment-spread we need to copy over the key-value
+        //   into our variable-values.
+        context.localVariableValues = fragment.variableDefinitions
+          ? getArgumentValuesFromSpread(
+              selection,
+              schema,
+              fragment.variableDefinitions,
+              variableValues,
+              context.localVariableValues,
+            )
+          : undefined;
+
         if (!newDeferUsage) {
-          visitedFragmentNames.add(fragName);
+          visitedFragmentNames.add(fragmentName);
           collectFieldsImpl(
             context,
             fragment.selectionSet,

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -22,9 +22,9 @@ import {
 } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
-import type { GraphQLVariableSignature } from '../utilities/getVariableSignature.js';
 import { typeFromAST } from '../utilities/typeFromAST.js';
 
+import type { GraphQLVariableSignature } from './getVariableSignature.js';
 import { experimentalGetArgumentValues, getDirectiveValues } from './values.js';
 
 export interface DeferUsage {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -48,8 +48,6 @@ import { GraphQLStreamDirective } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 import { assertValidSchema } from '../type/validate.js';
 
-import { getVariableSignature } from '../utilities/getVariableSignature.js';
-
 import type { DeferUsageSet, ExecutionPlan } from './buildExecutionPlan.js';
 import { buildExecutionPlan } from './buildExecutionPlan.js';
 import type {
@@ -62,6 +60,7 @@ import {
   collectFields,
   collectSubfields as _collectSubfields,
 } from './collectFields.js';
+import { getVariableSignature } from './getVariableSignature.js';
 import { buildIncrementalResponse } from './IncrementalPublisher.js';
 import { mapAsyncIterable } from './mapAsyncIterable.js';
 import type {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -721,9 +721,10 @@ function executeField(
     // variables scope to fulfill any variable references.
     // TODO: find a way to memoize, in case this field is within a List type.
     const args = getArgumentValues(
-      fieldDef,
       fieldGroup[0].node,
+      fieldDef.args,
       exeContext.variableValues,
+      fieldGroup[0].fragmentVariableValues,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -1028,7 +1029,7 @@ function getStreamUsage(
   const stream = getDirectiveValues(
     GraphQLStreamDirective,
     fieldGroup[0].node,
-    exeContext.variableValues,
+    fieldGroup[0].fragmentVariableValues ?? exeContext.variableValues,
   );
 
   if (!stream) {
@@ -2051,7 +2052,12 @@ function executeSubscription(
 
     // Build a JS object of arguments from the field.arguments AST, using the
     // variables scope to fulfill any variable references.
-    const args = getArgumentValues(fieldDef, fieldNodes[0], variableValues);
+    const args = getArgumentValues(
+      fieldNodes[0],
+      fieldDef.args,
+      variableValues,
+      undefined,
+    );
 
     // The resolve function's optional third argument is a context value that
     // is provided to every resolve function within an execution. It is commonly

--- a/src/execution/getVariableSignature.ts
+++ b/src/execution/getVariableSignature.ts
@@ -1,17 +1,19 @@
 import { GraphQLError } from '../error/GraphQLError.js';
 
+import type { VariableDefinitionNode } from '../language/ast.js';
 import { print } from '../language/printer.js';
 
+import { isInputType } from '../type/definition.js';
 import type { GraphQLInputType, GraphQLSchema } from '../type/index.js';
-import { isInputType } from '../type/index.js';
 
-import type { VariableDefinitionNode } from '../index.js';
-
-import { typeFromAST } from './typeFromAST.js';
-import { valueFromAST } from './valueFromAST.js';
+import { typeFromAST } from '../utilities/typeFromAST.js';
+import { valueFromAST } from '../utilities/valueFromAST.js';
 
 /**
  * A GraphQLVariableSignature is required to coerce a variable value.
+ *
+ * Designed to have comparable interface to GraphQLArgument so that
+ * getArgumentValues() can be reused for fragment arguments.
  * */
 export interface GraphQLVariableSignature {
   name: string;

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -20,11 +20,11 @@ import type { GraphQLDirective } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
 import { coerceInputValue } from '../utilities/coerceInputValue.js';
-import type { GraphQLVariableSignature } from '../utilities/getVariableSignature.js';
-import { getVariableSignature } from '../utilities/getVariableSignature.js';
 import { valueFromAST } from '../utilities/valueFromAST.js';
 
 import type { FragmentVariables } from './collectFields.js';
+import type { GraphQLVariableSignature } from './getVariableSignature.js';
+import { getVariableSignature } from './getVariableSignature.js';
 
 type CoercedVariableValues =
   | { errors: ReadonlyArray<GraphQLError>; coerced?: never }

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -14,15 +14,17 @@ import type {
 import { Kind } from '../language/kinds.js';
 import { print } from '../language/printer.js';
 
-import type { GraphQLArgument } from '../type/definition.js';
-import { isInputType, isNonNullType } from '../type/definition.js';
+import type { GraphQLArgument, GraphQLField } from '../type/definition.js';
+import { isNonNullType } from '../type/definition.js';
 import type { GraphQLDirective } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
 import { coerceInputValue } from '../utilities/coerceInputValue.js';
-import { typeFromAST } from '../utilities/typeFromAST.js';
+import type { GraphQLVariableSignature } from '../utilities/getVariableSignature.js';
+import { getVariableSignature } from '../utilities/getVariableSignature.js';
 import { valueFromAST } from '../utilities/valueFromAST.js';
-import { valueFromASTUntyped } from '../utilities/valueFromASTUntyped.js';
+
+import type { FragmentVariables } from './collectFields.js';
 
 type CoercedVariableValues =
   | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
@@ -70,14 +72,6 @@ export function getVariableValues(
   return { errors };
 }
 
-/**
- * Prepares an object map of argument values given a list of argument
- * definitions and list of argument AST nodes.
- *
- * Note: The returned value is a plain Object with a prototype, since it is
- * exposed to user code. Care should be taken to not pull values from the
- * Object prototype.
- */
 function coerceVariableValues(
   schema: GraphQLSchema,
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
@@ -86,24 +80,16 @@ function coerceVariableValues(
 ): { [variable: string]: unknown } {
   const coercedValues: { [variable: string]: unknown } = {};
   for (const varDefNode of varDefNodes) {
-    const varName = varDefNode.variable.name.value;
-    const varType = typeFromAST(schema, varDefNode.type);
-    if (!isInputType(varType)) {
-      // Must use input types for variables. This should be caught during
-      // validation, however is checked again here for safety.
-      const varTypeStr = print(varDefNode.type);
-      onError(
-        new GraphQLError(
-          `Variable "$${varName}" expected value of type "${varTypeStr}" which cannot be used as an input type.`,
-          { nodes: varDefNode.type },
-        ),
-      );
+    const varSignature = getVariableSignature(schema, varDefNode);
+    if (varSignature instanceof GraphQLError) {
+      onError(varSignature);
       continue;
     }
 
+    const { name: varName, type: varType } = varSignature;
     if (!Object.hasOwn(inputs, varName)) {
       if (varDefNode.defaultValue) {
-        coercedValues[varName] = valueFromAST(varDefNode.defaultValue, varType);
+        coercedValues[varName] = varSignature.defaultValue;
       } else if (isNonNullType(varType)) {
         const varTypeStr = inspect(varType);
         onError(
@@ -159,15 +145,25 @@ function coerceVariableValues(
  * Object prototype.
  */
 export function getArgumentValues(
+  def: GraphQLField<unknown, unknown> | GraphQLDirective,
   node: FieldNode | DirectiveNode,
-  argDefs: ReadonlyArray<GraphQLArgument>,
+  variableValues?: Maybe<ObjMap<unknown>>,
+): { [argument: string]: unknown } {
+  return experimentalGetArgumentValues(node, def.args, variableValues);
+}
+
+export function experimentalGetArgumentValues(
+  node: FieldNode | DirectiveNode | FragmentSpreadNode,
+  argDefs: ReadonlyArray<GraphQLArgument | GraphQLVariableSignature>,
   variableValues: Maybe<ObjMap<unknown>>,
-  fragmentArgValues?: Maybe<ObjMap<unknown>>,
+  fragmentVariables?: Maybe<FragmentVariables>,
 ): { [argument: string]: unknown } {
   const coercedValues: { [argument: string]: unknown } = {};
-  const argNodeMap = new Map(
-    node.arguments?.map((arg) => [arg.name.value, arg]),
-  );
+
+  // FIXME: https://github.com/graphql/graphql-js/issues/2203
+  /* c8 ignore next */
+  const argumentNodes = node.arguments ?? [];
+  const argNodeMap = new Map(argumentNodes.map((arg) => [arg.name.value, arg]));
 
   for (const argDef of argDefs) {
     const name = argDef.name;
@@ -188,39 +184,32 @@ export function getArgumentValues(
     }
 
     const valueNode = argumentNode.value;
+    let isNull = valueNode.kind === Kind.NULL;
 
-    let hasValue = valueNode.kind !== Kind.NULL;
     if (valueNode.kind === Kind.VARIABLE) {
       const variableName = valueNode.name.value;
+      const scopedVariableValues = fragmentVariables?.signatures[variableName]
+        ? fragmentVariables.values
+        : variableValues;
       if (
-        fragmentArgValues != null &&
-        Object.hasOwn(fragmentArgValues, variableName)
+        scopedVariableValues == null ||
+        !Object.hasOwn(scopedVariableValues, variableName)
       ) {
-        hasValue = fragmentArgValues[variableName] != null;
-        if (!hasValue && argDef.defaultValue !== undefined) {
+        if (argDef.defaultValue !== undefined) {
           coercedValues[name] = argDef.defaultValue;
-          continue;
+        } else if (isNonNullType(argType)) {
+          throw new GraphQLError(
+            `Argument "${name}" of required type "${inspect(argType)}" ` +
+              `was provided the variable "$${variableName}" which was not provided a runtime value.`,
+            { nodes: valueNode },
+          );
         }
-      } else if (
-        variableValues != null &&
-        Object.hasOwn(variableValues, variableName)
-      ) {
-        hasValue = variableValues[variableName] != null;
-      } else if (argDef.defaultValue !== undefined) {
-        coercedValues[name] = argDef.defaultValue;
-        continue;
-      } else if (isNonNullType(argType)) {
-        throw new GraphQLError(
-          `Argument "${name}" of required type "${inspect(argType)}" ` +
-            `was provided the variable "$${variableName}" which was not provided a runtime value.`,
-          { nodes: valueNode },
-        );
-      } else {
         continue;
       }
+      isNull = scopedVariableValues[variableName] == null;
     }
 
-    if (!hasValue && isNonNullType(argType)) {
+    if (isNull && isNonNullType(argType)) {
       throw new GraphQLError(
         `Argument "${name}" of non-null type "${inspect(argType)}" ` +
           'must not be null.',
@@ -228,12 +217,12 @@ export function getArgumentValues(
       );
     }
 
-    // TODO: Make this follow the spec more closely
-    const coercedValue = valueFromAST(valueNode, argType, {
-      ...variableValues,
-      ...fragmentArgValues,
-    });
-
+    const coercedValue = valueFromAST(
+      valueNode,
+      argType,
+      variableValues,
+      fragmentVariables?.values,
+    );
     if (coercedValue === undefined) {
       // Note: ValuesOfCorrectTypeRule validation should catch this before
       // execution. This is a runtime check to ensure execution does not
@@ -243,79 +232,6 @@ export function getArgumentValues(
         { nodes: valueNode },
       );
     }
-    coercedValues[name] = coercedValue;
-  }
-  return coercedValues;
-}
-
-export function getArgumentValuesFromSpread(
-  /** NOTE: For error annotations only */
-  node: FragmentSpreadNode,
-  schema: GraphQLSchema,
-  fragmentVarDefs: ReadonlyArray<VariableDefinitionNode>,
-  variableValues: Maybe<ObjMap<unknown>>,
-  fragmentArgValues?: Maybe<ObjMap<unknown>>,
-): { [argument: string]: unknown } {
-  const coercedValues: { [argument: string]: unknown } = {};
-  const argNodeMap = new Map(
-    node.arguments?.map((arg) => [arg.name.value, arg]),
-  );
-
-  for (const varDef of fragmentVarDefs) {
-    const name = varDef.variable.name.value;
-    const argType = typeFromAST(schema, varDef.type);
-    const argumentNode = argNodeMap.get(name);
-
-    if (argumentNode == null) {
-      if (varDef.defaultValue !== undefined) {
-        coercedValues[name] = valueFromASTUntyped(varDef.defaultValue);
-      } else if (isNonNullType(argType)) {
-        throw new GraphQLError(
-          `Argument "${name}" of required type "${inspect(argType)}" ` +
-            'was not provided.',
-          { nodes: node },
-        );
-      } else {
-        coercedValues[name] = undefined;
-      }
-      continue;
-    }
-
-    const valueNode = argumentNode.value;
-
-    let hasValue = valueNode.kind !== Kind.NULL;
-    if (valueNode.kind === Kind.VARIABLE) {
-      const variableName = valueNode.name.value;
-      if (
-        fragmentArgValues != null &&
-        Object.hasOwn(fragmentArgValues, variableName)
-      ) {
-        hasValue = fragmentArgValues[variableName] != null;
-      } else if (
-        variableValues != null &&
-        Object.hasOwn(variableValues, variableName)
-      ) {
-        hasValue = variableValues[variableName] != null;
-      }
-    }
-
-    if (!hasValue && isNonNullType(argType)) {
-      throw new GraphQLError(
-        `Argument "${name}" of non-null type "${inspect(argType)}" ` +
-          'must not be null.',
-        { nodes: valueNode },
-      );
-    }
-
-    // TODO: Make this follow the spec more closely
-    let coercedValue;
-    if (argType && isInputType(argType)) {
-      coercedValue = valueFromAST(valueNode, argType, {
-        ...variableValues,
-        ...fragmentArgValues,
-      });
-    }
-
     coercedValues[name] = coercedValue;
   }
   return coercedValues;
@@ -336,12 +252,18 @@ export function getDirectiveValues(
   directiveDef: GraphQLDirective,
   node: { readonly directives?: ReadonlyArray<DirectiveNode> | undefined },
   variableValues?: Maybe<ObjMap<unknown>>,
+  fragmentVariables?: Maybe<FragmentVariables>,
 ): undefined | { [argument: string]: unknown } {
   const directiveNode = node.directives?.find(
     (directive) => directive.name.value === directiveDef.name,
   );
 
   if (directiveNode) {
-    return getArgumentValues(directiveNode, directiveDef.args, variableValues);
+    return experimentalGetArgumentValues(
+      directiveNode,
+      directiveDef.args,
+      variableValues,
+      fragmentVariables,
+    );
   }
 }

--- a/src/utilities/getVariableSignature.ts
+++ b/src/utilities/getVariableSignature.ts
@@ -1,0 +1,44 @@
+import { GraphQLError } from '../error/GraphQLError.js';
+
+import { print } from '../language/printer.js';
+
+import type { GraphQLInputType, GraphQLSchema } from '../type/index.js';
+import { isInputType } from '../type/index.js';
+
+import type { VariableDefinitionNode } from '../index.js';
+
+import { typeFromAST } from './typeFromAST.js';
+import { valueFromAST } from './valueFromAST.js';
+
+/**
+ * A GraphQLVariableSignature is required to coerce a variable value.
+ * */
+export interface GraphQLVariableSignature {
+  name: string;
+  type: GraphQLInputType;
+  defaultValue: unknown;
+}
+
+export function getVariableSignature(
+  schema: GraphQLSchema,
+  varDefNode: VariableDefinitionNode,
+): GraphQLVariableSignature | GraphQLError {
+  const varName = varDefNode.variable.name.value;
+  const varType = typeFromAST(schema, varDefNode.type);
+
+  if (!isInputType(varType)) {
+    // Must use input types for variables. This should be caught during
+    // validation, however is checked again here for safety.
+    const varTypeStr = print(varDefNode.type);
+    return new GraphQLError(
+      `Variable "$${varName}" expected value of type "${varTypeStr}" which cannot be used as an input type.`,
+      { nodes: varDefNode.type },
+    );
+  }
+
+  return {
+    name: varName,
+    type: varType,
+    defaultValue: valueFromAST(varDefNode.defaultValue, varType),
+  };
+}

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -38,6 +38,7 @@ export function valueFromAST(
   valueNode: Maybe<ValueNode>,
   type: GraphQLInputType,
   variables?: Maybe<ObjMap<unknown>>,
+  fragmentVariables?: Maybe<ObjMap<unknown>>,
 ): unknown {
   if (!valueNode) {
     // When there is no node, then there is also no value.
@@ -47,11 +48,12 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    if (variables == null || variables[variableName] === undefined) {
+    const variableValue =
+      fragmentVariables?.[variableName] ?? variables?.[variableName];
+    if (variableValue === undefined) {
       // No valid return value.
       return;
     }
-    const variableValue = variables[variableName];
     if (variableValue === null && isNonNullType(type)) {
       return; // Invalid: intentionally return no value.
     }
@@ -65,7 +67,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.NULL) {
       return; // Invalid: intentionally return no value.
     }
-    return valueFromAST(valueNode, type.ofType, variables);
+    return valueFromAST(valueNode, type.ofType, variables, fragmentVariables);
   }
 
   if (valueNode.kind === Kind.NULL) {
@@ -78,7 +80,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.LIST) {
       const coercedValues = [];
       for (const itemNode of valueNode.values) {
-        if (isMissingVariable(itemNode, variables)) {
+        if (isMissingVariable(itemNode, variables, fragmentVariables)) {
           // If an array contains a missing variable, it is either coerced to
           // null or if the item type is non-null, it considered invalid.
           if (isNonNullType(itemType)) {
@@ -86,7 +88,12 @@ export function valueFromAST(
           }
           coercedValues.push(null);
         } else {
-          const itemValue = valueFromAST(itemNode, itemType, variables);
+          const itemValue = valueFromAST(
+            itemNode,
+            itemType,
+            variables,
+            fragmentVariables,
+          );
           if (itemValue === undefined) {
             return; // Invalid: intentionally return no value.
           }
@@ -95,7 +102,12 @@ export function valueFromAST(
       }
       return coercedValues;
     }
-    const coercedValue = valueFromAST(valueNode, itemType, variables);
+    const coercedValue = valueFromAST(
+      valueNode,
+      itemType,
+      variables,
+      fragmentVariables,
+    );
     if (coercedValue === undefined) {
       return; // Invalid: intentionally return no value.
     }
@@ -112,7 +124,10 @@ export function valueFromAST(
     );
     for (const field of Object.values(type.getFields())) {
       const fieldNode = fieldNodes.get(field.name);
-      if (fieldNode == null || isMissingVariable(fieldNode.value, variables)) {
+      if (
+        fieldNode == null ||
+        isMissingVariable(fieldNode.value, variables, fragmentVariables)
+      ) {
         if (field.defaultValue !== undefined) {
           coercedObj[field.name] = field.defaultValue;
         } else if (isNonNullType(field.type)) {
@@ -120,7 +135,12 @@ export function valueFromAST(
         }
         continue;
       }
-      const fieldValue = valueFromAST(fieldNode.value, field.type, variables);
+      const fieldValue = valueFromAST(
+        fieldNode.value,
+        field.type,
+        variables,
+        fragmentVariables,
+      );
       if (fieldValue === undefined) {
         return; // Invalid: intentionally return no value.
       }
@@ -166,9 +186,12 @@ export function valueFromAST(
 function isMissingVariable(
   valueNode: ValueNode,
   variables: Maybe<ObjMap<unknown>>,
+  fragmentVariables: Maybe<ObjMap<unknown>>,
 ): boolean {
   return (
     valueNode.kind === Kind.VARIABLE &&
+    (fragmentVariables == null ||
+      fragmentVariables[valueNode.name.value] === undefined) &&
     (variables == null || variables[valueNode.name.value] === undefined)
   );
 }

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -2,15 +2,14 @@ import type { ObjMap } from '../../jsutils/ObjMap.js';
 
 import { GraphQLError } from '../../error/GraphQLError.js';
 
-import type {
-  FieldNode,
-  FragmentDefinitionNode,
-  OperationDefinitionNode,
-} from '../../language/ast.js';
+import type { FieldNode, OperationDefinitionNode } from '../../language/ast.js';
 import { Kind } from '../../language/kinds.js';
 import type { ASTVisitor } from '../../language/visitor.js';
 
-import type { FieldGroup } from '../../execution/collectFields.js';
+import type {
+  FieldGroup,
+  FragmentDetails,
+} from '../../execution/collectFields.js';
 import { collectFields } from '../../execution/collectFields.js';
 
 import type { ValidationContext } from '../ValidationContext.js';
@@ -41,10 +40,10 @@ export function SingleFieldSubscriptionsRule(
             [variable: string]: any;
           } = Object.create(null);
           const document = context.getDocument();
-          const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
+          const fragments: ObjMap<FragmentDetails> = Object.create(null);
           for (const definition of document.definitions) {
             if (definition.kind === Kind.FRAGMENT_DEFINITION) {
-              fragments[definition.name.value] = definition;
+              fragments[definition.name.value] = { definition };
             }
           }
           const { groupedFieldSet } = collectFields(


### PR DESCRIPTION
This implements execution of Fragment Arguments, and more specifically collecting-fields and replacing the variables in a fragment-definition with values coming from the fragment-spread, as described by the spec changes in https://github.com/graphql/graphql-spec/pull/1010.

This is a 2024 update of https://github.com/graphql/graphql-js/pull/3835 where all discussions have been carried over in code comments, they are highlighted already as review comments here as well.

This PR splits out the execution part so we can look at that in detail, I will pause here as the fragment-keying remarks will most likely have quite an impact on the validation changes.