### PR TITLE
fixes execution to always use fragment variable rather than operation variable

### DIFF
--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -1335,6 +1335,22 @@ describe('Execute: Handles inputs', () => {
       });
     });
 
+    it('when a nullable argument without a field default is not provided and shadowed by an operation variable', () => {
+      const result = executeQueryWithFragmentArguments(`
+        query($x: String = "A") {
+          ...a
+        }
+        fragment a($x: String) on TestType {
+          fieldWithNullableStringInput(input: $x)
+        }
+      `);
+      expect(result).to.deep.equal({
+        data: {
+          fieldWithNullableStringInput: null,
+        },
+      });
+    });
+
     it('when a nullable argument with a field default is not provided and shadowed by an operation variable', () => {
       const result = executeQueryWithFragmentArguments(`
         query($x: String = "A") {


### PR DESCRIPTION
previously, we were allowing an operation variable to be used if the fragment variable was not provided, and the field had no default. Now, we still use the fragment variable, and so the value is null.

this now correct logic allows us to significantly reduce the diff from main

adds additional test