### PR TITLE
OverlappingFieldsCanBeMergedRule suggestions

### DIFF
--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -292,6 +292,12 @@ export class ValidationContext extends ASTValidationContext {
     return this._typeInfo.getFragmentSignature();
   }
 
+  getFragmentSignatureByName(): (
+    fragmentName: string,
+  ) => Maybe<FragmentSignature> {
+    return this._typeInfo.getFragmentSignatureByName();
+  }
+
   getEnumValue(): Maybe<GraphQLEnumValue> {
     return this._typeInfo.getEnumValue();
   }

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1303,20 +1303,20 @@ describe('Validate: Overlapping fields can be merged', () => {
       ]);
     });
 
-    it('encounters conflict in fragment - field no args', () => {
-      expectErrors(`
+    it('allows operations with overlapping fields with arguments using identical operation variables', () => {
+      expectValid(`
         query ($y: Int = 1) {
           a(x: $y)
-          ...WithArgs
+          ...WithArgs(x: 1)
         }
-        fragment WithArgs on Type {
+        fragment WithArgs($x: Int = 1) on Type {
           a(x: $y)
         }
-      `).toDeepEqual([]);
+      `);
     });
 
-    it('encounters conflict in fragment/field', () => {
-      expectErrors(`
+    it('allows operations with overlapping fields with identical variable arguments passed via fragment arguments', () => {
+      expectValid(`
         query ($y: Int = 1) {
           a(x: $y)
           ...WithArgs(x: $y)
@@ -1324,10 +1324,113 @@ describe('Validate: Overlapping fields can be merged', () => {
         fragment WithArgs($x: Int) on Type {
           a(x: $x)
         }
-      `).toDeepEqual([]);
+      `);
     });
 
-    // This is currently not validated, should we?
+    it('allows operations with overlapping fields with identical variable arguments passed via nested fragment arguments', () => {
+      expectValid(`
+        query ($z: Int = 1) {
+          a(x: $z)
+          ...WithArgs(y: $z)
+        }
+        fragment WithArgs($y: Int) on Type {
+          ...NestedWithArgs(x: $y)
+        }
+        fragment NestedWithArgs($x: Int) on Type {
+          a(x: $x)
+        }
+      `);
+    });
+
+    it('allows operations with overlapping fields with identical arguments via fragment variable defaults', () => {
+      expectValid(`
+        query {
+          a(x: 1)
+          ...WithArgs
+        }
+        fragment WithArgs($x: Int = 1) on Type {
+          a(x: $x)
+        }
+      `);
+    });
+
+    it('raises errors with overlapping fields with arguments that conflict via operation variables even with defaults and fragment variable defaults', () => {
+      expectErrors(`
+        query ($y: Int = 1) {
+          a(x: $y)
+          ...WithArgs
+        }
+        fragment WithArgs($x: Int = 1) on Type {
+          a(x: $x)
+        }
+      `).toDeepEqual([
+        {
+          message:
+            'Fields "a" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional.',
+          locations: [
+            { line: 3, column: 11 },
+            { line: 7, column: 11 },
+          ],
+        },
+      ]);
+    });
+
+    it('allows operations with overlapping list fields with identical variable arguments passed via fragment arguments', () => {
+      expectValid(`
+        query Query($stringListVarY: [String]) {
+          complicatedArgs {
+            stringListArgField(stringListArg: $stringListVarY)
+            ...WithArgs(stringListVarX: $stringListVarY)
+          }
+        }
+        fragment WithArgs($stringListVarX: [String]) on Type {
+          stringListArgField(stringListArg: $stringListVarX)
+        }
+      `);
+    });
+
+    it('allows operations with overlapping list fields with identical variable arguments in item position passed via fragment arguments', () => {
+      expectValid(`
+        query Query($stringListVarY: [String]) {
+          complicatedArgs {
+            stringListArgField(stringListArg: [$stringListVarY])
+            ...WithArgs(stringListVarX: $stringListVarY)
+          }
+        }
+        fragment WithArgs($stringListVarX: [String]) on Type {
+          stringListArgField(stringListArg: [$stringListVarX])
+        }
+      `);
+    });
+
+    it('allows operations with overlapping input object fields with identical variable arguments passed via fragment arguments', () => {
+      expectValid(`
+        query Query($complexVarY: ComplexInput) {
+          complicatedArgs {
+            complexArgField(complexArg: $complexVarY)
+            ...WithArgs(complexVarX: $complexVarY)
+          }
+        }
+        fragment WithArgs($complexVarX: ComplexInput) on Type {
+          complexArgField(complexArg: $complexVarX)
+        }
+      `);
+    });
+
+    it('allows operations with overlapping input object fields with identical variable arguments in field position passed via fragment arguments', () => {
+      expectValid(`
+        query Query($boolVarY: Boolean) {
+          complicatedArgs {
+            complexArgField(complexArg: {requiredArg: $boolVarY})
+            ...WithArgs(boolVarX: $boolVarY)
+          }
+        }
+        fragment WithArgs($boolVarX: Boolean) on Type {
+          complexArgField(complexArg: {requiredArg: $boolVarX})
+        }
+      `);
+    });
+
     it('encounters nested field conflict in fragments that could otherwise merge', () => {
       expectErrors(`
         query ValidDifferingFragmentArgs($command1: DogCommand, $command2: DogCommand) {

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -16,7 +16,6 @@ import type {
 import { Kind } from '../../language/kinds.js';
 import { print } from '../../language/printer.js';
 import type { ASTVisitor } from '../../language/visitor.js';
-import { visit } from '../../language/visitor.js';
 
 import type {
   GraphQLField,
@@ -71,7 +70,7 @@ export function OverlappingFieldsCanBeMergedRule(
   // dramatically improve the performance of this validator.
   const comparedFragmentPairs = new PairSet();
 
-  // A cache for the "field map" and list of fragment names found in any given
+  // A cache for the "field map" and list of fragment spreads found in any given
   // selection set. Selection sets may be asked for this information multiple
   // times, so this improves the performance of this validator.
   const cachedFieldsAndFragmentSpreads = new Map();
@@ -111,10 +110,15 @@ type NodeAndDef = [
 ];
 // Map of array of those.
 type NodeAndDefCollection = Map<string, Array<NodeAndDef>>;
-type FragmentSpreadsByName = Map<string, Array<FragmentSpreadNode>>;
+interface FragmentSpread {
+  key: string;
+  node: FragmentSpreadNode;
+  varMap: Map<string, ValueNode> | undefined;
+}
+type FragmentSpreads = ReadonlyArray<FragmentSpread>;
 type FieldsAndFragmentSpreads = readonly [
   NodeAndDefCollection,
-  FragmentSpreadsByName,
+  FragmentSpreads,
 ];
 
 /**
@@ -172,78 +176,67 @@ type FieldsAndFragmentSpreads = readonly [
  *
  */
 
-const printFragmentSpreadArguments = (fragmentSpread: FragmentSpreadNode) => {
-  if (!fragmentSpread.arguments || fragmentSpread.arguments.length === 0) {
-    return fragmentSpread.name.value;
-  }
-
-  const printedArguments: Array<string> = fragmentSpread.arguments
-    .map(print)
-    .sort((a, b) => a.localeCompare(b));
-  return fragmentSpread.name.value + '(' + printedArguments.join(',') + ')';
-};
-
 // Find all conflicts found "within" a selection set, including those found
 // via spreading in fragments. Called when visiting each SelectionSet in the
 // GraphQL Document.
 function findConflictsWithinSelectionSet(
   context: ValidationContext,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   parentType: Maybe<GraphQLNamedType>,
   selectionSet: SelectionSetNode,
 ): Array<Conflict> {
   const conflicts: Array<Conflict> = [];
 
-  const [fieldMap, fragmentSpreadMap] = getFieldsAndFragmentSpreads(
+  const [fieldMap, fragmentSpreads] = getFieldsAndFragmentSpreads(
     context,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     parentType,
     selectionSet,
+    undefined,
   );
 
-  // (A) First find all conflicts "within" the fields and fragment-spreads of this selection set.
+  // (A) Find find all conflicts "within" the fields and f of this selection set.
   // Note: this is the *only place* `collectConflictsWithin` is called.
   collectConflictsWithin(
     context,
     conflicts,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     comparedFragmentPairs,
     fieldMap,
   );
 
-  const allFragmentSpreads = [];
-  for (const [, fragmentSpreads] of fragmentSpreadMap.entries()) {
-    allFragmentSpreads.push(...fragmentSpreads);
-  }
-
-  // (B) Then collect conflicts between these fields and those represented by
-  // each spread fragment name found.
-  for (let i = 0; i < allFragmentSpreads.length; i++) {
-    collectConflictsBetweenFieldsAndFragment(
-      context,
-      conflicts,
-      cachedFieldsAndFragmentNames,
-      comparedFragmentPairs,
-      false,
-      fieldMap,
-      allFragmentSpreads[i],
-    );
-
-    // (C) Then compare this fragment with all other fragments found in this
-    // selection set to collect conflicts between fragments spread together.
-    // This compares each item in the list of fragment names to every other
-    // item in that same list (except for itself).
-    for (let j = i + 1; j < allFragmentSpreads.length; j++) {
-      collectConflictsBetweenFragments(
+  if (fragmentSpreads.length !== 0) {
+    // (B) Then collect conflicts between these fields and those represented by
+    // each spread found.
+    for (let i = 0; i < fragmentSpreads.length; i++) {
+      collectConflictsBetweenFieldsAndFragment(
         context,
         conflicts,
-        cachedFieldsAndFragmentNames,
+        cachedFieldsAndFragmentSpreads,
         comparedFragmentPairs,
         false,
-        allFragmentSpreads[i],
-        allFragmentSpreads[j],
+        fieldMap,
+        fragmentSpreads[i],
       );
+      // (C) Then compare this fragment with all other fragments found in this
+      // selection set to collect conflicts between fragments spread together.
+      // This compares each item in the list of fragment spreads to every other
+      // item in that same list (except for itself).
+      for (let j = i + 1; j < fragmentSpreads.length; j++) {
+        collectConflictsBetweenFragments(
+          context,
+          conflicts,
+          cachedFieldsAndFragmentSpreads,
+          comparedFragmentPairs,
+          false,
+          fragmentSpreads[i],
+          fragmentSpreads[j],
+        );
+      }
     }
   }
   return conflicts;
@@ -254,24 +247,26 @@ function findConflictsWithinSelectionSet(
 function collectConflictsBetweenFieldsAndFragment(
   context: ValidationContext,
   conflicts: Array<Conflict>,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   areMutuallyExclusive: boolean,
   fieldMap: NodeAndDefCollection,
-  fragmentSpread: FragmentSpreadNode,
+  fragmentSpread: FragmentSpread,
 ): void {
-  const fragmentName = fragmentSpread.name.value;
-  const fragment = context.getFragment(fragmentName);
+  const fragment = context.getFragment(fragmentSpread.node.name.value);
   if (!fragment) {
     return;
   }
 
-  const [fieldMap2, referencedFragmentNames] =
+  const [fieldMap2, referencedFragmentSpreads] =
     getReferencedFieldsAndFragmentSpreads(
       context,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       fragment,
-      fragmentSpread,
+      fragmentSpread.varMap,
     );
 
   // Do not compare a fragment's fieldMap to itself.
@@ -284,43 +279,42 @@ function collectConflictsBetweenFieldsAndFragment(
   collectConflictsBetween(
     context,
     conflicts,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     comparedFragmentPairs,
     areMutuallyExclusive,
     fieldMap,
+    undefined,
     fieldMap2,
+    fragmentSpread.varMap,
   );
 
   // (E) Then collect any conflicts between the provided collection of fields
-  // and any fragment names found in the given fragment.
-  for (const [
-    referencedFragmentName,
-    [spread],
-  ] of referencedFragmentNames.entries()) {
+  // and any fragment spreads found in the given fragment.
+  for (const referencedFragmentSpread of referencedFragmentSpreads) {
     // Memoize so two fragments are not compared for conflicts more than once.
     if (
       comparedFragmentPairs.has(
-        referencedFragmentName,
-        fragmentName,
+        referencedFragmentSpread.key,
+        fragmentSpread.key,
         areMutuallyExclusive,
       )
     ) {
       continue;
     }
     comparedFragmentPairs.add(
-      referencedFragmentName,
-      fragmentName,
+      referencedFragmentSpread.key,
+      fragmentSpread.key,
       areMutuallyExclusive,
     );
 
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       comparedFragmentPairs,
       areMutuallyExclusive,
       fieldMap,
-      spread,
+      referencedFragmentSpread,
     );
   }
 }
@@ -330,66 +324,74 @@ function collectConflictsBetweenFieldsAndFragment(
 function collectConflictsBetweenFragments(
   context: ValidationContext,
   conflicts: Array<Conflict>,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   areMutuallyExclusive: boolean,
-  fragmentSpread1: FragmentSpreadNode,
-  fragmentSpread2: FragmentSpreadNode,
+  fragmentSpread1: FragmentSpread,
+  fragmentSpread2: FragmentSpread,
 ): void {
-  const fragmentName1 = fragmentSpread1.name.value;
-  const fragmentName2 = fragmentSpread2.name.value;
   // No need to compare a fragment to itself.
-  if (
-    fragmentName1 === fragmentName2 &&
-    !sameArguments(fragmentSpread1, fragmentSpread2)
-  ) {
-    context.reportError(
-      new GraphQLError(
-        `Spreads "${fragmentName1}" conflict because ${printFragmentSpreadArguments(
-          fragmentSpread1,
-        )} and ${printFragmentSpreadArguments(
-          fragmentSpread2,
-        )} have different fragment arguments.`,
-        { nodes: [fragmentSpread1, fragmentSpread2] },
-      ),
-    );
+  if (fragmentSpread1.key === fragmentSpread2.key) {
     return;
   }
 
-  if (
-    fragmentName1 === fragmentName2 &&
-    sameArguments(fragmentSpread1, fragmentSpread2)
-  ) {
-    return;
+  if (fragmentSpread1.node.name.value === fragmentSpread2.node.name.value) {
+    if (
+      !sameArguments(
+        fragmentSpread1.node.arguments,
+        fragmentSpread1.varMap,
+        fragmentSpread2.node.arguments,
+        fragmentSpread2.varMap,
+      )
+    ) {
+      context.reportError(
+        new GraphQLError(
+          `Spreads "${fragmentSpread1.node.name.value}" conflict because ${fragmentSpread1.key} and ${fragmentSpread2.key} have different fragment arguments.`,
+          { nodes: [fragmentSpread1.node, fragmentSpread2.node] },
+        ),
+      );
+      return;
+    }
   }
 
-  const fragKey1 = printFragmentSpreadArguments(fragmentSpread1);
-  const fragKey2 = printFragmentSpreadArguments(fragmentSpread2);
   // Memoize so two fragments are not compared for conflicts more than once.
-  if (comparedFragmentPairs.has(fragKey1, fragKey2, areMutuallyExclusive)) {
+  if (
+    comparedFragmentPairs.has(
+      fragmentSpread1.key,
+      fragmentSpread2.key,
+      areMutuallyExclusive,
+    )
+  ) {
     return;
   }
-  comparedFragmentPairs.add(fragKey1, fragKey2, areMutuallyExclusive);
+  comparedFragmentPairs.add(
+    fragmentSpread1.key,
+    fragmentSpread2.key,
+    areMutuallyExclusive,
+  );
 
-  const fragment1 = context.getFragment(fragmentName1);
-  const fragment2 = context.getFragment(fragmentName2);
+  const fragment1 = context.getFragment(fragmentSpread1.node.name.value);
+  const fragment2 = context.getFragment(fragmentSpread2.node.name.value);
   if (!fragment1 || !fragment2) {
     return;
   }
 
-  const [fieldMap1, referencedFragmentNames1] =
+  const [fieldMap1, referencedFragmentSpreads1] =
     getReferencedFieldsAndFragmentSpreads(
       context,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       fragment1,
-      fragmentSpread1,
+      fragmentSpread1.varMap,
     );
-  const [fieldMap2, referencedFragmentNames2] =
+  const [fieldMap2, referencedFragmentSpreads2] =
     getReferencedFieldsAndFragmentSpreads(
       context,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       fragment2,
-      fragmentSpread2,
+      fragmentSpread2.varMap,
     );
 
   // (F) First, collect all conflicts between these two collections of fields
@@ -397,20 +399,22 @@ function collectConflictsBetweenFragments(
   collectConflictsBetween(
     context,
     conflicts,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     comparedFragmentPairs,
     areMutuallyExclusive,
     fieldMap1,
+    fragmentSpread1.varMap,
     fieldMap2,
+    fragmentSpread2.varMap,
   );
 
   // (G) Then collect conflicts between the first fragment and any nested
   // fragments spread in the second fragment.
-  for (const [referencedFragmentSpread2] of referencedFragmentNames2.values()) {
+  for (const referencedFragmentSpread2 of referencedFragmentSpreads2) {
     collectConflictsBetweenFragments(
       context,
       conflicts,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       comparedFragmentPairs,
       areMutuallyExclusive,
       fragmentSpread1,
@@ -420,14 +424,14 @@ function collectConflictsBetweenFragments(
 
   // (G) Then collect conflicts between the second fragment and any nested
   // fragments spread in the first fragment.
-  for (const [referencedFragmentName1] of referencedFragmentNames1.values()) {
+  for (const referencedFragmentSpread1 of referencedFragmentSpreads1) {
     collectConflictsBetweenFragments(
       context,
       conflicts,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       comparedFragmentPairs,
       areMutuallyExclusive,
-      referencedFragmentName1,
+      referencedFragmentSpread1,
       fragmentSpread2,
     );
   }
@@ -438,47 +442,56 @@ function collectConflictsBetweenFragments(
 // between the sub-fields of two overlapping fields.
 function findConflictsBetweenSubSelectionSets(
   context: ValidationContext,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   areMutuallyExclusive: boolean,
   parentType1: Maybe<GraphQLNamedType>,
   selectionSet1: SelectionSetNode,
+  varMap1: Map<string, ValueNode> | undefined,
   parentType2: Maybe<GraphQLNamedType>,
   selectionSet2: SelectionSetNode,
+  varMap2: Map<string, ValueNode> | undefined,
 ): Array<Conflict> {
   const conflicts: Array<Conflict> = [];
 
-  const [fieldMap1, fragmentSpreadsByName1] = getFieldsAndFragmentSpreads(
+  const [fieldMap1, fragmentSpreads1] = getFieldsAndFragmentSpreads(
     context,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     parentType1,
     selectionSet1,
+    varMap1,
   );
-  const [fieldMap2, fragmentSpreadsByName2] = getFieldsAndFragmentSpreads(
+  const [fieldMap2, fragmentSpreads2] = getFieldsAndFragmentSpreads(
     context,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     parentType2,
     selectionSet2,
+    varMap2,
   );
 
   // (H) First, collect all conflicts between these two collections of field.
   collectConflictsBetween(
     context,
     conflicts,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     comparedFragmentPairs,
     areMutuallyExclusive,
     fieldMap1,
+    varMap1,
     fieldMap2,
+    varMap2,
   );
 
   // (I) Then collect conflicts between the first collection of fields and
   // those referenced by each fragment name associated with the second.
-  for (const [fragmentSpread2] of fragmentSpreadsByName2.values()) {
+  for (const fragmentSpread2 of fragmentSpreads2) {
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       comparedFragmentPairs,
       areMutuallyExclusive,
       fieldMap1,
@@ -488,11 +501,11 @@ function findConflictsBetweenSubSelectionSets(
 
   // (I) Then collect conflicts between the second collection of fields and
   // those referenced by each fragment name associated with the first.
-  for (const [fragmentSpread1] of fragmentSpreadsByName1.values()) {
+  for (const fragmentSpread1 of fragmentSpreads1) {
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       comparedFragmentPairs,
       areMutuallyExclusive,
       fieldMap2,
@@ -500,19 +513,19 @@ function findConflictsBetweenSubSelectionSets(
     );
   }
 
-  // (J) Also collect conflicts between any fragment names by the first and
-  // fragment names by the second. This compares each item in the first set of
-  // names to each item in the second set of names.
-  for (const [fragmentName1] of fragmentSpreadsByName1.values()) {
-    for (const [fragmentName2] of fragmentSpreadsByName2.values()) {
+  // (J) Also collect conflicts between any fragment spreads by the first and
+  // fragment spreads by the second. This compares each item in the first set of
+  // spreads to each item in the second set of spreads.
+  for (const fragmentSpread1 of fragmentSpreads1) {
+    for (const fragmentSpread2 of fragmentSpreads2) {
       collectConflictsBetweenFragments(
         context,
         conflicts,
-        cachedFieldsAndFragmentNames,
+        cachedFieldsAndFragmentSpreads,
         comparedFragmentPairs,
         areMutuallyExclusive,
-        fragmentName1,
-        fragmentName2,
+        fragmentSpread1,
+        fragmentSpread2,
       );
     }
   }
@@ -523,7 +536,10 @@ function findConflictsBetweenSubSelectionSets(
 function collectConflictsWithin(
   context: ValidationContext,
   conflicts: Array<Conflict>,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   fieldMap: NodeAndDefCollection,
 ): void {
@@ -540,12 +556,14 @@ function collectConflictsWithin(
         for (let j = i + 1; j < fields.length; j++) {
           const conflict = findConflict(
             context,
-            cachedFieldsAndFragmentNames,
+            cachedFieldsAndFragmentSpreads,
             comparedFragmentPairs,
             false, // within one collection is never mutually exclusive
             responseName,
             fields[i],
+            undefined,
             fields[j],
+            undefined,
           );
           if (conflict) {
             conflicts.push(conflict);
@@ -564,11 +582,16 @@ function collectConflictsWithin(
 function collectConflictsBetween(
   context: ValidationContext,
   conflicts: Array<Conflict>,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   parentFieldsAreMutuallyExclusive: boolean,
   fieldMap1: NodeAndDefCollection,
+  varMap1: Map<string, ValueNode> | undefined,
   fieldMap2: NodeAndDefCollection,
+  varMap2: Map<string, ValueNode> | undefined,
 ): void {
   // A field map is a keyed collection, where each key represents a response
   // name and the value at that key is a list of all fields which provide that
@@ -582,12 +605,14 @@ function collectConflictsBetween(
         for (const field2 of fields2) {
           const conflict = findConflict(
             context,
-            cachedFieldsAndFragmentNames,
+            cachedFieldsAndFragmentSpreads,
             comparedFragmentPairs,
             parentFieldsAreMutuallyExclusive,
             responseName,
             field1,
+            varMap1,
             field2,
+            varMap2,
           );
           if (conflict) {
             conflicts.push(conflict);
@@ -602,12 +627,17 @@ function collectConflictsBetween(
 // comparing their sub-fields.
 function findConflict(
   context: ValidationContext,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   comparedFragmentPairs: PairSet,
   parentFieldsAreMutuallyExclusive: boolean,
   responseName: string,
   field1: NodeAndDef,
+  varMap1: Map<string, ValueNode> | undefined,
   field2: NodeAndDef,
+  varMap2: Map<string, ValueNode> | undefined,
 ): Maybe<Conflict> {
   const [parentType1, node1, def1] = field1;
   const [parentType2, node2, def2] = field2;
@@ -639,7 +669,7 @@ function findConflict(
     }
 
     // Two field calls must have the same arguments.
-    if (!sameArguments(node1, node2)) {
+    if (!sameArguments(node1.arguments, varMap1, node2.arguments, varMap2)) {
       return [
         [responseName, 'they have differing arguments'],
         [node1],
@@ -651,7 +681,7 @@ function findConflict(
   // FIXME https://github.com/graphql/graphql-js/issues/2203
   const directives1 = /* c8 ignore next */ node1.directives ?? [];
   const directives2 = /* c8 ignore next */ node2.directives ?? [];
-  if (!sameStreams(directives1, directives2)) {
+  if (!sameStreams(directives1, varMap1, directives2, varMap2)) {
     return [
       [responseName, 'they have differing stream directives'],
       [node1],
@@ -676,7 +706,7 @@ function findConflict(
     ];
   }
 
-  // Collect and compare sub-fields. Use the same "visited fragment names" list
+  // Collect and compare sub-fields. Use the same "visited fragment spreads" list
   // for both collections so fields in a fragment reference are never
   // compared to themselves.
   const selectionSet1 = node1.selectionSet;
@@ -684,25 +714,26 @@ function findConflict(
   if (selectionSet1 && selectionSet2) {
     const conflicts = findConflictsBetweenSubSelectionSets(
       context,
-      cachedFieldsAndFragmentNames,
+      cachedFieldsAndFragmentSpreads,
       comparedFragmentPairs,
       areMutuallyExclusive,
       getNamedType(type1),
       selectionSet1,
+      varMap1,
       getNamedType(type2),
       selectionSet2,
+      varMap2,
     );
     return subfieldConflicts(conflicts, responseName, node1, node2);
   }
 }
 
-function sameArguments(
-  node1: FieldNode | DirectiveNode | FragmentSpreadNode,
-  node2: FieldNode | DirectiveNode | FragmentSpreadNode,
+function sameArguments<T extends ArgumentNode | FragmentArgumentNode>(
+  args1: ReadonlyArray<T> | undefined,
+  varMap1: Map<string, ValueNode> | undefined,
+  args2: ReadonlyArray<T> | undefined,
+  varMap2: Map<string, ValueNode> | undefined,
 ): boolean {
-  const args1 = node1.arguments;
-  const args2 = node2.arguments;
-
   if (args1 === undefined || args1.length === 0) {
     return args2 === undefined || args2.length === 0;
   }
@@ -714,9 +745,17 @@ function sameArguments(
     return false;
   }
 
-  const values2 = new Map(args2.map(({ name, value }) => [name.value, value]));
-  return (args1 as Array<FragmentArgumentNode | ArgumentNode>).every((arg1) => {
-    const value1 = arg1.value;
+  const values2 = new Map(
+    args2.map(({ name, value }) => [
+      name.value,
+      varMap2 === undefined ? value : replaceFragmentVariables(value, varMap2),
+    ]),
+  );
+  return args1.every((arg1) => {
+    let value1 = arg1.value;
+    if (varMap1) {
+      value1 = replaceFragmentVariables(value1, varMap1);
+    }
     const value2 = values2.get(arg1.name.value);
     if (value2 === undefined) {
       return false;
@@ -724,6 +763,34 @@ function sameArguments(
 
     return stringifyValue(value1) === stringifyValue(value2);
   });
+}
+
+function replaceFragmentVariables(
+  valueNode: ValueNode,
+  varMap: ReadonlyMap<string, ValueNode>,
+): ValueNode {
+  switch (valueNode.kind) {
+    case Kind.VARIABLE:
+      return varMap.get(valueNode.name.value) ?? valueNode;
+    case Kind.LIST:
+      return {
+        ...valueNode,
+        values: valueNode.values.map((node) =>
+          replaceFragmentVariables(node, varMap),
+        ),
+      };
+    case Kind.OBJECT:
+      return {
+        ...valueNode,
+        fields: valueNode.fields.map((field) => ({
+          ...field,
+          value: replaceFragmentVariables(field.value, varMap),
+        })),
+      };
+    default: {
+      return valueNode;
+    }
+  }
 }
 
 function stringifyValue(value: ValueNode): string | null {
@@ -738,7 +805,9 @@ function getStreamDirective(
 
 function sameStreams(
   directives1: ReadonlyArray<DirectiveNode>,
+  varMap1: Map<string, ValueNode> | undefined,
   directives2: ReadonlyArray<DirectiveNode>,
+  varMap2: Map<string, ValueNode> | undefined,
 ): boolean {
   const stream1 = getStreamDirective(directives1);
   const stream2 = getStreamDirective(directives2);
@@ -747,7 +816,12 @@ function sameStreams(
     return true;
   } else if (stream1 && stream2) {
     // check if both fields have equivalent streams
-    return sameArguments(stream1, stream2);
+    return sameArguments(
+      stream1.arguments,
+      varMap1,
+      stream2.arguments,
+      varMap2,
+    );
   }
   // fields have a mix of stream and no stream
   return false;
@@ -783,55 +857,53 @@ function doTypesConflict(
 }
 
 // Given a selection set, return the collection of fields (a mapping of response
-// name to field nodes and definitions) as well as a list of fragment names
+// name to field nodes and definitions) as well as a list of fragment spreads
 // referenced via fragment spreads.
 function getFieldsAndFragmentSpreads(
   context: ValidationContext,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   parentType: Maybe<GraphQLNamedType>,
   selectionSet: SelectionSetNode,
+  varMap: Map<string, ValueNode> | undefined,
 ): FieldsAndFragmentSpreads {
-  const cached = cachedFieldsAndFragmentNames.get(selectionSet);
+  const cached = cachedFieldsAndFragmentSpreads.get(selectionSet);
   if (cached) {
     return cached;
   }
   const nodeAndDefs: NodeAndDefCollection = new Map();
-  const fragmentSpreadsByName = new Map<string, Array<FragmentSpreadNode>>();
-  _collectFieldsAndFragmentNames(
+  const fragmentSpreads = new Map<string, FragmentSpread>();
+  _collectFieldsAndFragmentSpreads(
     context,
     parentType,
     selectionSet,
     nodeAndDefs,
-    fragmentSpreadsByName,
+    fragmentSpreads,
+    varMap,
   );
-  const result = [nodeAndDefs, fragmentSpreadsByName] as const;
-  cachedFieldsAndFragmentNames.set(selectionSet, result);
+  const result: FieldsAndFragmentSpreads = [
+    nodeAndDefs,
+    Array.from(fragmentSpreads.values()),
+  ];
+  cachedFieldsAndFragmentSpreads.set(selectionSet, result);
   return result;
 }
 
 // Given a reference to a fragment, return the represented collection of fields
-// as well as a list of nested fragment spreads.
+// as well as a list of nested fragment spreads referenced via fragment spreads.
 function getReferencedFieldsAndFragmentSpreads(
   context: ValidationContext,
-  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentSpreads>,
+  cachedFieldsAndFragmentSpreads: Map<
+    SelectionSetNode,
+    FieldsAndFragmentSpreads
+  >,
   fragment: FragmentDefinitionNode,
-  fragmentSpread: FragmentSpreadNode,
+  varMap: Map<string, ValueNode> | undefined,
 ) {
-  const args = fragmentSpread.arguments;
-  const fragmentSelectionSet = visit(fragment.selectionSet, {
-    Variable: (node) => {
-      const name = node.name.value;
-      const argNode = args?.find((arg) => arg.name.value === name);
-      if (argNode) {
-        return argNode.value;
-      }
-
-      return node;
-    },
-  });
-
   // Short-circuit building a type from the node if possible.
-  const cached = cachedFieldsAndFragmentNames.get(fragmentSelectionSet);
+  const cached = cachedFieldsAndFragmentSpreads.get(fragment.selectionSet);
   if (cached) {
     return cached;
   }
@@ -839,18 +911,20 @@ function getReferencedFieldsAndFragmentSpreads(
   const fragmentType = typeFromAST(context.getSchema(), fragment.typeCondition);
   return getFieldsAndFragmentSpreads(
     context,
-    cachedFieldsAndFragmentNames,
+    cachedFieldsAndFragmentSpreads,
     fragmentType,
-    fragmentSelectionSet,
+    fragment.selectionSet,
+    varMap,
   );
 }
 
-function _collectFieldsAndFragmentNames(
+function _collectFieldsAndFragmentSpreads(
   context: ValidationContext,
   parentType: Maybe<GraphQLNamedType>,
   selectionSet: SelectionSetNode,
   nodeAndDefs: NodeAndDefCollection,
-  fragmentSpreadsByName: Map<string, Array<FragmentSpreadNode>>,
+  fragmentSpreads: Map<string, FragmentSpread>,
+  varMap: Map<string, ValueNode> | undefined,
 ): void {
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {
@@ -873,12 +947,8 @@ function _collectFieldsAndFragmentNames(
         break;
       }
       case Kind.FRAGMENT_SPREAD: {
-        const existing = fragmentSpreadsByName.get(selection.name.value);
-        if (existing) {
-          existing.push(selection);
-        } else {
-          fragmentSpreadsByName.set(selection.name.value, [selection]);
-        }
+        const fragmentSpread = getFragmentSpread(context, selection, varMap);
+        fragmentSpreads.set(fragmentSpread.key, fragmentSpread);
         break;
       }
       case Kind.INLINE_FRAGMENT: {
@@ -886,17 +956,60 @@ function _collectFieldsAndFragmentNames(
         const inlineFragmentType = typeCondition
           ? typeFromAST(context.getSchema(), typeCondition)
           : parentType;
-        _collectFieldsAndFragmentNames(
+        _collectFieldsAndFragmentSpreads(
           context,
           inlineFragmentType,
           selection.selectionSet,
           nodeAndDefs,
-          fragmentSpreadsByName,
+          fragmentSpreads,
+          varMap,
         );
         break;
       }
     }
   }
+}
+
+function getFragmentSpread(
+  context: ValidationContext,
+  fragmentSpreadNode: FragmentSpreadNode,
+  varMap: Map<string, ValueNode> | undefined,
+): FragmentSpread {
+  let key = '';
+  const newVarMap = new Map<string, ValueNode>();
+  const fragmentSignature = context.getFragmentSignatureByName()(
+    fragmentSpreadNode.name.value,
+  );
+  const argMap = new Map<string, ValueNode>();
+  if (fragmentSpreadNode.arguments) {
+    for (const arg of fragmentSpreadNode.arguments) {
+      argMap.set(arg.name.value, arg.value);
+    }
+  }
+  if (fragmentSignature?.variableDefinitions) {
+    key += fragmentSpreadNode.name.value + '(';
+    for (const [varName, variable] of fragmentSignature.variableDefinitions) {
+      const value = argMap.get(varName);
+      if (value) {
+        key += varName + ': ' + print(sortValueNode(value));
+      }
+      const arg = argMap.get(varName);
+      if (arg !== undefined) {
+        newVarMap.set(
+          varName,
+          varMap !== undefined ? replaceFragmentVariables(arg, varMap) : arg,
+        );
+      } else if (variable.defaultValue) {
+        newVarMap.set(varName, variable.defaultValue);
+      }
+    }
+    key += ')';
+  }
+  return {
+    key,
+    node: fragmentSpreadNode,
+    varMap: newVarMap.size > 0 ? newVarMap : undefined,
+  };
 }
 
 // Given a series of Conflicts which occurred between two sub-fields, generate


### PR DESCRIPTION
-- Removes visiting fragment definitions in favor of a `replaceFragmentVariables()` utility function that essentially only visits the variables within fragments.
-- Renames "fragment names" throughout the file to refer to "fragment spreads."